### PR TITLE
Fix errors

### DIFF
--- a/release.py
+++ b/release.py
@@ -115,6 +115,13 @@ def create_option_parser():
     parser.add_option_group(rel_group)
     
     rel_group.add_option(
+        "--release",
+        action="store_true",
+        dest="release",
+        help="Update the changelog, push the tag, upload to Github, and upload to PyPi."
+    )
+    
+    rel_group.add_option(
         "--github",
         action="store_true",
         dest="github",
@@ -345,6 +352,11 @@ if __name__ == "__main__":
     pargs[0] = Path(pargs[0]).resolve()
     
     # Actions
+    if opts.release:
+        opts.changelog = True
+        opts.tag = True
+        opt.github = True
+        opt.pypi = True
     if opts.changelog:
         update_changelog(opts, pargs)
     if opts.tag:

--- a/release.py
+++ b/release.py
@@ -217,7 +217,7 @@ def update_changelog(opts, pargs):
                     continue
                     
                 # New entry
-                if key is not None and row.strip() != "":
+                if key is not None and "<news item>" not in row and row.strip() != "":
                     changes[key].append(row) 
     
     # Write to changelog

--- a/release.py
+++ b/release.py
@@ -5,7 +5,12 @@ import subprocess
 
 import optparse
 import sys
+import shlex
 from pathlib import Path
+
+def call(cmd, cwd):
+    cmd_list = shlex.split(cmd)
+    subprocess.run(cmd_list, cwd=cwd)
 
 def create_option_parser():
     prog_name_short = Path(sys.argv[0]).name  # Program name
@@ -35,6 +40,8 @@ def create_option_parser():
     
     vsn_group.add_option(
         "--version-bump",
+        metavar="VBREGEX",
+        dest="vb_regex"
     )
     
     vsn_group.add_option(
@@ -46,23 +53,23 @@ def create_option_parser():
     
     vsn_group.add_option(
         "--cl-file",
-        metavar="FILENAME",
+        metavar="FILEPATH",
         dest="cl_file",
-        help="Name of changelog file."
+        help="Name (and path if not in root) of changelog file. Default \'CHANGELOG.rst\'"
     )
     
     vsn_group.add_option(
         "--cl-news",
         metavar="NEWSDIR",
         dest="cl_news",
-        help="Location of news directory."
+        help="Location of news directory. Default is \'news\' in the root directory."
     )
     
     vsn_group.add_option(
         "--cl-template",
         metavar="TEMPLATE",
         dest="cl_template",
-        help="Name of template file. One will be auto-generated if one does not exist."
+        help="Name of template file. One will be auto-generated if one does not exist. Default \'TEMPLATE.rst\'."
     )
     
     vsn_group.add_option(
@@ -91,6 +98,13 @@ def create_option_parser():
         action="store_true",
         dest="tag",
         help="Create and push a version tag to GitHub."
+    )
+    
+    vsn_group.add_option(
+        "--upstream",
+        action="store_true",
+        dest="upstream",
+        help="Push to upstream rather than origin."
     )
     
     rel_group = optparse.OptionGroup(
@@ -156,7 +170,7 @@ def update_changelog(opts, pargs):
         news = opts.cl_news
     news = release_dir / news
     if not news.exists():
-        subprocess.run(f"mkdir {news.name}", shell=True, check=True)
+        call(f"mkdir {news.name}", release_dir)
     
     # Files to ignore
     ignore = []
@@ -182,7 +196,7 @@ def update_changelog(opts, pargs):
     if opts.cl_file is not None:
         changelog = opts.cl_file
     ignore.append(changelog)
-    changelog = news / changelog
+    changelog = (release_dir / changelog).resolve()
     if not changelog.exists():
         with open(changelog, 'w') as cf:
             generated_changelog = "=============\nRelease Notes\n=============\n\n.. current developments\n"
@@ -197,7 +211,7 @@ def update_changelog(opts, pargs):
         with open(change_file, 'r') as cf:
             for row in cf:
                 # New key
-                rx = re.search("\*\*(.+):\*\*", row)
+                rx = re.search(r"\*\*(.+):\*\*", row)
                 if rx:
                     key = rx.group(1)
                     continue
@@ -217,9 +231,10 @@ def update_changelog(opts, pargs):
             sep += "="
         generated_update = f"{version}\n{sep}\n"
         for key in changes.keys():
-            generated_update += f"\n**{key}:**\n"
-            key_updates = "".join(changes[key])
-            generated_update += f"\n{key_updates}"
+            if len(changes[key]) > 0:
+                generated_update += f"\n**{key}:**\n"
+                key_updates = "".join(changes[key])
+                generated_update += f"\n{key_updates}"
         
         # Write update after access point
         line = cf.readline()
@@ -248,11 +263,15 @@ def update_changelog(opts, pargs):
         change_file.unlink()
 
 def push_tag(opts, pargs):
+    release_dir = pargs[0]
     version = pargs[1]
     
-    # Create and push tag to upstream (must have upstream access)
-    subprocess.run(f"git tag {version}", shell=True, check=True)
-    subprocess.run(f"git push upstream {version}", shell=True, check=True)
+    # Create and push tag to origin (must have origin release access)
+    call(f"git tag {version}", release_dir)
+    if opts.upstream is not None:
+        call(f"git push upstream {version}", release_dir)
+    else:
+        call(f"git push origin {version}", release_dir)
 
 # TODO: Implement environment and permissions checks
 def check():
@@ -266,15 +285,15 @@ def github_release(opts, pargs):
     tmp_dir = "release_tmp"
     while (Path(release_dir) / tmp_dir).exists():
         tmp_dir += "_prime"
-    subprocess.run(f"mkdir {tmp_dir}", shell=True, check=True)
+    call(f"mkdir {tmp_dir}", release_dir)
     
     # Build tar
     project = Path(release_dir).name
     tgz_name = f"{project}-{version}.tar.gz"
-    subprocess.run(f"tar --exclude=\"./{tmp_dir}\" -zcf \"./{tmp_dir}/{tgz_name}\" . ", shell=True, check=True)
+    call(f"tar --exclude=\"./{tmp_dir}\" -zcf \"./{tmp_dir}/{tgz_name}\" . ", release_dir)
     
     # Set notes and title if user has not provided any
-    gh_notes = "generate_notes"
+    gh_notes = "--generate-notes"
     if opts.gh_notes is not None:
         gh_notes = f"-n {opts.gh_notes}"
     gh_title = f"-t {version}"
@@ -282,20 +301,33 @@ def github_release(opts, pargs):
         gh_title = f"-t {opts.gh_title}"
     
     # Release through gh
-    subprocess.run(f"gh release create \"{version}\" \"./{tmp_dir}/{tgz_name}\" \"{gh_title}\" \"{gh_notes}\"", shell=True, check=True)
+    call(f"gh release create \"{version}\" \"./{tmp_dir}/{tgz_name}\" \"{gh_title}\" \"{gh_notes}\"", release_dir)
     
     # Cleanup
-    subprocess.run(f"rm -rf {tmp_dir}", shell=True, check=True)
+    call(f"rm -rf {tmp_dir}", release_dir)
         
 def pypi_release(opts, pargs):
+    release_dir = pargs[0]
     version = pargs[1]
 
     # Build distribution (build will fail if there have been no changes since the previous version)
-    subprocess.run("python -m build", shell=True, check=True)
+    call("python -m build", release_dir)
     
     # Upload using twine
-    subprocess.run(f"twine upload dist/*{version}*.tar.gz || echo \"Warning: No new distribution build. Check for any untracked changes.\"", shell=True, check=True)
-
+    no_tar = True
+    no_whl = True
+    for file in list((release_dir / "dist").iterdir()):
+        if re.search(f".*{version}.*.tar.gz", file.name):
+            no_tar = False
+        if re.search(f".*{version}.*.whl", file.name):
+            no_whl = False
+    if no_tar:
+        call(f"echo \"Warning: No new distribution build. Check for any untracked changes.\"", release_dir)
+    elif no_whl:
+        call(f"echo \"Warning: No wheel found.\"", release_dir)
+    else:
+        call(f"twine upload dist/*{version}*.tar.gz dist/*{version}*.whl", release_dir)
+    
 # TODO: Implement anaconda release (push to feedstock)
 def conda_release(opts, pargs):
     pass
@@ -309,9 +341,8 @@ if __name__ == "__main__":
     if len(pargs) > 2:
         parser.error("Improper usage. Too many arguments!")
     
-    # Go to release directory
+    # Set release directory to absolute path
     pargs[0] = Path(pargs[0]).resolve()
-    subprocess.run(f"cd {pargs[0]}", shell=True, check=True)
     
     # Actions
     if opts.changelog:


### PR DESCRIPTION
- Added `--release` tag to update the changelog, push the tag, and upload to GitHub and PyPi
- Default names (`CHANGELOG.rst`, `TEMPLATE.rst`, `news` directory) included in `--help` menu
- `CHANGELOG.rst` default to root rather than news (can specify path in options)
- Change default to push to origin (added option `--upstream` to push to upstream instead)
- Fix `--generate-notes`
- Ensure correct directory by setting `cwd` of `subprocess.run()` command
- Remove `shell=True` for security reasons