### PR TITLE
Add interactive Conda-forge release script

### DIFF
--- a/cf_release.py
+++ b/cf_release.py
@@ -235,8 +235,8 @@ def main():
     SHA256 = pypi_version_info[new_version]
     print(
         f"You've selected version {new_version} with SHA256 "
-        f"{format_sha(SHA256)} for {package_name}. "
-        "We will now update the meta.yaml file and create a PR to the feedstock repository."
+        f"{format_sha(SHA256)} for {package_name}."
+        "\nWe will now update the meta.yaml file and create a PR to the feedstock repository."
     )
 
     # Get the GitHub username using the GitHub CLI

--- a/cf_release.py
+++ b/cf_release.py
@@ -62,7 +62,7 @@ def get_package_versions_SHA(package_name, count=5):
         return version_info
     else:
         error_message = (
-            f"ERROR: No matching package has been found for {package_name}. "
+            f"No matching package has been found for {package_name}. "
             "Please double check the package name or visit "
             "https://pypi.org to check whether your package exists."
         )
@@ -79,7 +79,7 @@ def get_feedstock_and_meta_file_path(package_name):
     # Check if the meta file exists to ensure the path is correct
     if not exists(meta_file_path):
         error_message = (
-            f"ERROR: meta.yaml file not found. Please re-run after checking whether {package_name}-feedstock "
+            f"meta.yaml file not found. Please re-run after checking whether {package_name}-feedstock "
             "exists in the dev folder Please also check the folder strucutre provided in the "
             "GitLab documentation: https://www.gitlab.com/learn/conda-forge#dev-folder-structure"
         )
@@ -125,9 +125,7 @@ def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username):
     run_command("git add recipe/meta.yaml", cwd=cwd)
 
     # Commit the changes
-    run_command(
-        f'git commit -m "Update conda package to {version}"', cwd=cwd
-    )
+    run_command(f'git commit -m "Update conda package to {version}"', cwd=cwd)
 
     # Push the new branch to your origin repository
     run_command(f"git push origin {version}", cwd=cwd)
@@ -193,7 +191,9 @@ Main Entry Point
 
 def main():
     # Q1 Ask the package name from the user
-    package_name = prompt("Q1. Please enter the PyPI package name Ex) diffpy.pdfgui", type=str)
+    package_name = prompt(
+        "Q1. Please enter the PyPI package name Ex) diffpy.pdfgui", type=str
+    )
 
     try:
         # Get path to feedstock directory and meta.yaml file
@@ -205,8 +205,7 @@ def main():
         pypi_version_info = get_package_versions_SHA(package_name)
 
     except (FileNotFoundError, ValueError) as e:
-        print(str(e))
-        sys.exit(1)
+        raise Exception(e)
 
     # Print the latest versions of the package
     print_available_package_info(package_name, pypi_version_info)
@@ -237,8 +236,7 @@ def main():
     try:
         username = get_github_username()
     except RuntimeError as e:
-        print(str(e))
-        sys.exit(1)
+        raise Exception(e)
 
     # Run the shell command to update the .yml file and create a PR
     run_gh_shell_command(
@@ -247,4 +245,7 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception as e:
+        print(f"Error: {str(e)}")

--- a/cf_release.py
+++ b/cf_release.py
@@ -84,8 +84,7 @@ def get_feedstock_and_meta_file_path(package_name):
     if not exists(meta_file_path):
         error_message = (
             f"meta.yaml file not found. Please re-run after checking whether {package_name}-feedstock "
-            "exists in the dev folder Please also check the folder strucutre provided in the "
-            "GitLab documentation: https://www.gitlab.com/learn/conda-forge#dev-folder-structure"
+            "exists in the dev folder and the meta.yaml file is present in the recipe folder."
         )
 
         raise FileNotFoundError(error_message)
@@ -240,13 +239,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except RuntimeError as e:
-        print(f"Runtime Error: {str(e)}")
-    except ValueError as e:
-        print(f"Value Error: {str(e)}")
-    except FileNotFoundError as e:
-        print(f"File Not Found Error: {str(e)}")
-    except Exception as e:
-        print(f"Unexpected Error: {str(e)}")
+    main()

--- a/cf_release.py
+++ b/cf_release.py
@@ -106,32 +106,31 @@ def update_meta_yaml(meta_file_path, new_version, new_sha256):
             file.write(line)
 
 
-def run_gh_shell_command(fd_stock_dir_path, meta_file_path, version, SHA256, username):
+def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username):
     """
     Create a PR from a branch name of <new_version>
     to the main branch of the feedstock repository.
     """
-
     # Check out main and pull the latest changes
-    run_command("git checkout main", cwd=fd_stock_dir_path)
-    run_command("git pull upstream main", cwd=fd_stock_dir_path)
+    run_command("git checkout main", cwd=cwd)
+    run_command("git pull upstream main", cwd=cwd)
 
     # Create and switch to a new branch named after the new version
-    run_command(f"git checkout -b {version}", cwd=fd_stock_dir_path)
+    run_command(f"git checkout -b {version}", cwd=cwd)
 
     # Update the meta.yaml file
     update_meta_yaml(meta_file_path, version, SHA256)
 
     # Add the updated meta.yaml file to the staging area
-    run_command("git add recipe/meta.yaml", cwd=fd_stock_dir_path)
+    run_command("git add recipe/meta.yaml", cwd=cwd)
 
     # Commit the changes
     run_command(
-        f'git commit -m "Update conda package to {version}"', cwd=fd_stock_dir_path
+        f'git commit -m "Update conda package to {version}"', cwd=cwd
     )
 
     # Push the new branch to your origin repository
-    run_command(f"git push origin {version}", cwd=fd_stock_dir_path)
+    run_command(f"git push origin {version}", cwd=cwd)
 
     # Create a pull request using GitHub CLI
     pr_command = (
@@ -141,7 +140,7 @@ def run_gh_shell_command(fd_stock_dir_path, meta_file_path, version, SHA256, use
     )
 
     # Run the PR create command in the appropriate directory
-    run_command(pr_command, cwd=fd_stock_dir_path)
+    run_command(pr_command, cwd=cwd)
 
 
 """

--- a/cf_release.py
+++ b/cf_release.py
@@ -12,12 +12,12 @@ PR into the GitHub feedstock repository.
 Workflow:
 
 - The user is prompted to enter the name of a PyPI package.
-- Retrieves the feedstock directory and meta.yaml file paths
-- Fetches the latest versions and SHA256 hashes from PyPI.
-- Displays the latest PyPI versions, asking the user to choose the version.
-- Fetches the user's GitHub username using the GitHub CLI for authentication
-- Updates the meta.yaml file with the new version and SHA256
-- Commits these changes, pushes them to GitHub, and creates a PR
+- Retrieve the feedstock directory and meta.yaml file paths
+- Fetch the latest versions and SHA256 hashes from PyPI.
+- Display the latest PyPI versions, asking the user to choose the version.
+- Fetch the user's GitHub username using the GitHub CLI for authentication
+- Update the meta.yaml file with the new version and SHA256
+- Commit these changes, pushes them to GitHub, and creates a PR
 """
 
 """
@@ -154,7 +154,7 @@ User Prompts
 """
 
 
-def prompt_is_latest_version(pypi_version_info):
+def prompt_is_latest_version_used(pypi_version_info):
     latest_version = next(iter(pypi_version_info))
     use_latest_version = confirm(
         f"\nQ2. Would you like to proceed with the latest version {latest_version}?",
@@ -163,7 +163,7 @@ def prompt_is_latest_version(pypi_version_info):
     return use_latest_version
 
 
-def print_latest_package_verison(package_name, pypi_version_info):
+def print_available_package_info(package_name, pypi_version_info):
     print(f"\nThe latest versions of {package_name} are:")
 
     for i, (version, sha) in enumerate(pypi_version_info.items()):
@@ -178,7 +178,7 @@ GitHub Integration
 """
 
 
-def get_github_username_via_gh():
+def get_github_username():
     """Get the GitHub username using the GitHub CLI."""
     try:
         username = subprocess.check_output(
@@ -199,7 +199,7 @@ Main Entry Point
 
 def main():
     # Q1 Ask the package name from the user
-    package_name = prompt("Q1. Please enter the PyPI package name Ex) numpy", type=str)
+    package_name = prompt("Q1. Please enter the PyPI package name Ex) diffpy.pdfgui", type=str)
 
     try:
         # Get path to feedstock directory and meta.yaml file
@@ -215,11 +215,10 @@ def main():
         sys.exit(1)
 
     # Print the latest versions of the package
-    print_latest_package_verison(package_name, pypi_version_info)
+    print_available_package_info(package_name, pypi_version_info)
 
-    # Q2. Ask the user if they want to proceed with the latest version
-    if prompt_is_latest_version(pypi_version_info):
-        # If the user confirms, proceed with the latest version
+    # Q2. Ask user to proceed with the latest version
+    if prompt_is_latest_version_used(pypi_version_info):
         new_version = next(iter(pypi_version_info))
         print(f"Using latest version: {new_version}")
     else:
@@ -235,14 +234,14 @@ def main():
     # Get the SHA256 hash for the selected version
     SHA256 = pypi_version_info[new_version]
     print(
-        f"Great, you have selected version {new_version} with SHA256 "
+        f"You've selected version {new_version} with SHA256 "
         f"{format_sha(SHA256)} for {package_name}. "
         "We will now update the meta.yaml file and create a PR to the feedstock repository."
     )
 
     # Get the GitHub username using the GitHub CLI
     try:
-        username = get_github_username_via_gh()
+        username = get_github_username()
     except RuntimeError as e:
         print(str(e))
         sys.exit(1)

--- a/cf_release.py
+++ b/cf_release.py
@@ -9,6 +9,10 @@ This script streamlines the process of updating Python package versions and
 their corresponding SHA256 hash in a meta.yaml file, followed by creating a
 PR into the GitHub feedstock repository.
 
+How to use:
+
+python /path/.../cf_release.py
+
 Workflow:
 
 - The user is prompted to enter the name of a PyPI package.
@@ -195,17 +199,11 @@ def main():
         "Q1. Please enter the PyPI package name Ex) diffpy.pdfgui", type=str
     )
 
-    try:
-        # Get path to feedstock directory and meta.yaml file
-        fd_stock_dir_path, meta_file_path = get_feedstock_and_meta_file_path(
-            package_name
-        )
+    # Get path to feedstock directory and meta.yaml file
+    fd_stock_dir_path, meta_file_path = get_feedstock_and_meta_file_path(package_name)
 
-        # Get the latest versions and SHA256 hashes from PyPI
-        pypi_version_info = get_package_versions_SHA(package_name)
-
-    except (FileNotFoundError, ValueError) as e:
-        raise Exception(e)
+    # Get the latest versions and SHA256 hashes from PyPI
+    pypi_version_info = get_package_versions_SHA(package_name)
 
     # Print the latest versions of the package
     print_available_package_info(package_name, pypi_version_info)
@@ -233,10 +231,7 @@ def main():
     )
 
     # Get the GitHub username using the GitHub CLI
-    try:
-        username = get_github_username()
-    except RuntimeError as e:
-        raise Exception(e)
+    username = get_github_username()
 
     # Run the shell command to update the .yml file and create a PR
     run_gh_shell_command(
@@ -247,5 +242,11 @@ def main():
 if __name__ == "__main__":
     try:
         main()
+    except RuntimeError as e:
+        print(f"Runtime Error: {str(e)}")
+    except ValueError as e:
+        print(f"Value Error: {str(e)}")
+    except FileNotFoundError as e:
+        print(f"File Not Found Error: {str(e)}")
     except Exception as e:
-        print(f"Error: {str(e)}")
+        print(f"Unexpected Error: {str(e)}")

--- a/cf_release.py
+++ b/cf_release.py
@@ -236,7 +236,7 @@ def main():
     print(
         f"You've selected version {new_version} with SHA256 "
         f"{format_sha(SHA256)} for {package_name}."
-        "\nWe will now update the meta.yaml file and create a PR to the feedstock repository."
+        "\nWe will now update the meta.yaml file and create a PR into the feedstock repository."
     )
 
     # Get the GitHub username using the GitHub CLI

--- a/cf_release.py
+++ b/cf_release.py
@@ -1,0 +1,257 @@
+import sys
+import requests
+import subprocess
+from os.path import join, exists, dirname
+from click import prompt, confirm
+
+"""
+This script streamlines the process of updating Python package versions and
+their corresponding SHA256 hash in a meta.yaml file, followed by creating a
+PR into the GitHub feedstock repository.
+
+Workflow:
+
+- The user is prompted to enter the name of a PyPI package.
+- Retrieves the feedstock directory and meta.yaml file paths
+- Fetches the latest versions and SHA256 hashes from PyPI.
+- Displays the latest PyPI versions, asking the user to choose the version.
+- Fetches the user's GitHub username using the GitHub CLI for authentication
+- Updates the meta.yaml file with the new version and SHA256
+- Commits these changes, pushes them to GitHub, and creates a PR
+"""
+
+"""
+Utility Functions
+"""
+
+
+def format_sha(sha):
+    """Return a truncated version of the SHA256 hash."""
+    return sha[:4] + "..." + sha[-4:]
+
+
+def run_command(command, cwd=None):
+    """Run a shell command in the specified directory."""
+    subprocess.run(
+        command,
+        check=True,
+        shell=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+"""
+Core Functionalities - fetch info from PyPI, update meta.yaml and create PR
+"""
+
+
+def get_package_versions_SHA(package_name, count=5):
+    """Fetch the latest versions of the package and their SHA256 from PyPI."""
+    response = requests.get(f"https://pypi.org/pypi/{package_name}/json")
+    if response.status_code == 200:
+        data = response.json()
+        versions = sorted(data["releases"].keys(), reverse=True)[:count]
+        version_info = {}
+        for version in versions:
+            files = data["releases"][version]
+            for file in files:
+                if file["packagetype"] == "sdist":
+                    version_info[version] = file["digests"]["sha256"]
+                    break
+        return version_info
+    else:
+        error_message = (
+            f"ERROR: No matching package has been found for {package_name}. "
+            "Please double check the package name or visit "
+            "https://pypi.org to check whether your package exists."
+        )
+
+        raise ValueError(error_message)
+
+
+def get_feedstock_and_meta_file_path(package_name):
+    release_scripts_dir_path = dirname(sys.argv[0])
+    dev_dir_path = dirname(release_scripts_dir_path)
+    feedstock_dir_path = join(dev_dir_path, f"{package_name}-feedstock")
+    meta_file_path = join(feedstock_dir_path, "recipe", "meta.yaml")
+
+    # Check if the meta file exists to ensure the path is correct
+    if not exists(meta_file_path):
+        error_message = (
+            f"ERROR: meta.yaml file not found. Please re-run after checking whether {package_name}-feedstock "
+            "exists in the dev folder Please also check the folder strucutre provided in the "
+            "GitLab documentation: https://www.gitlab.com/learn/conda-forge#dev-folder-structure"
+        )
+
+        raise FileNotFoundError(error_message)
+
+    return feedstock_dir_path, meta_file_path
+
+
+def update_meta_yaml(meta_file_path, new_version, new_sha256):
+    """
+    Update the meta.yaml file with the new version and SHA256 hash
+    before making a PR to the feedstock repository.
+    """
+    with open(meta_file_path, "r") as file:
+        lines = file.readlines()
+
+    with open(meta_file_path, "w") as file:
+        for line in lines:
+            if "{%- set version =" in line:
+                line = f'{{%- set version = "{new_version}" -%}}\n'
+            elif "sha256:" in line:
+                line = f"  sha256: {new_sha256}\n"
+            file.write(line)
+
+
+def run_gh_shell_command(fd_stock_dir_path, meta_file_path, version, SHA256, username):
+    """
+    Create a PR from a branch name of <new_version>
+    to the main branch of the feedstock repository.
+    """
+    try:
+        # Check out main and pull the latest changes
+        run_command("git checkout main", cwd=fd_stock_dir_path)
+        run_command("git pull upstream main", cwd=fd_stock_dir_path)
+
+        # Create and switch to a new branch named after the new version
+        run_command(f"git checkout -b {version}", cwd=fd_stock_dir_path)
+
+        # Update the meta.yaml file
+        update_meta_yaml(meta_file_path, version, SHA256)
+
+        # Add the updated meta.yaml file to the staging area
+        run_command("git add recipe/meta.yaml", cwd=fd_stock_dir_path)
+
+        # Commit the changes
+        run_command(
+            f'git commit -m "Update conda package to {version}"', cwd=fd_stock_dir_path
+        )
+
+        # Push the new branch to your origin repository
+        run_command(f"git push origin {version}", cwd=fd_stock_dir_path)
+
+        # Create a pull request using GitHub CLI
+        pr_command = (
+            f"gh pr create --base main --head {username}:{version} "
+            f"--title 'Update meta.yaml to {version}' "
+            f"--body 'Updated meta.yaml to version {version} with SHA value of {SHA256}'"
+        )
+
+        # Run the PR create command in the appropriate directory
+        run_command(pr_command, cwd=fd_stock_dir_path)
+
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to execute command: {e.cmd}")
+        print(f"Error message: {e.stderr}")
+        raise
+
+
+"""
+User Prompts
+"""
+
+
+def prompt_is_latest_version(pypi_version_info):
+    latest_version = next(iter(pypi_version_info))
+    use_latest_version = confirm(
+        f"\nQ2. Would you like to proceed with the latest version {latest_version}?",
+        default=True,
+    )
+    return use_latest_version
+
+
+def print_latest_package_verison(package_name, pypi_version_info):
+    print(f"\nThe latest versions of {package_name} are:")
+
+    for i, (version, sha) in enumerate(pypi_version_info.items()):
+        if i < 4:  # Display only the first 4 versions
+            print(f" - Version: {version}, SHA256: {format_sha(sha)}")
+        else:
+            break
+
+
+"""
+GitHub Integration
+"""
+
+
+def get_github_username_via_gh():
+    """Get the GitHub username using the GitHub CLI."""
+    try:
+        username = subprocess.check_output(
+            ["gh", "api", "user", "--jq", ".login"], text=True
+        ).strip()
+        return username
+    except subprocess.CalledProcessError:
+        raise RuntimeError(
+            "Could not retrieve GitHub username using GitHub CLI. "
+            "Please make sure your local machine is authenticated with GitHub."
+        )
+
+
+"""
+Main Entry Point
+"""
+
+
+def main():
+    # Q1 Ask the package name from the user
+    package_name = prompt("Q1. Please enter the PyPI package name Ex) numpy", type=str)
+
+    try:
+        # Get path to feedstock directory and meta.yaml file
+        fd_stock_dir_path, meta_file_path = get_feedstock_and_meta_file_path(
+            package_name
+        )
+
+        # Get the latest versions and SHA256 hashes from PyPI
+        pypi_version_info = get_package_versions_SHA(package_name)
+
+    except (FileNotFoundError, ValueError) as e:
+        print(str(e))
+        sys.exit(1)
+
+    # Print the latest versions of the package
+    print_latest_package_verison(package_name, pypi_version_info)
+
+    # Q2. Ask the user if they want to proceed with the latest version
+    if prompt_is_latest_version(pypi_version_info):
+        # If the user confirms, proceed with the latest version
+        new_version = next(iter(pypi_version_info))
+        print(f"Using latest version: {new_version}")
+    else:
+        # Allow user to use a different version
+        new_version = prompt("Please enter the version you would like to use", type=str)
+        while new_version not in pypi_version_info:
+            new_version = prompt(
+                f"ERROR: {new_version} is not available in the list of versions. "
+                "Please re-enter",
+                type=str,
+            )
+
+    # Get the SHA256 hash for the selected version
+    SHA256 = pypi_version_info[new_version]
+    print(
+        f"Great, you have selected version {new_version} with SHA256 "
+        f"{format_sha(SHA256)} for {package_name}. "
+        "We will now update the meta.yaml file and create a PR to the feedstock repository."
+    )
+
+    # Get the GitHub username using the GitHub CLI
+    try:
+        username = get_github_username_via_gh()
+    except RuntimeError as e:
+        print(str(e))
+        sys.exit(1)
+
+    # Run the shell command to update the .yml file and create a PR
+    run_gh_shell_command(
+        fd_stock_dir_path, meta_file_path, new_version, SHA256, username
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/cf_release.py
+++ b/cf_release.py
@@ -111,42 +111,37 @@ def run_gh_shell_command(fd_stock_dir_path, meta_file_path, version, SHA256, use
     Create a PR from a branch name of <new_version>
     to the main branch of the feedstock repository.
     """
-    try:
-        # Check out main and pull the latest changes
-        run_command("git checkout main", cwd=fd_stock_dir_path)
-        run_command("git pull upstream main", cwd=fd_stock_dir_path)
 
-        # Create and switch to a new branch named after the new version
-        run_command(f"git checkout -b {version}", cwd=fd_stock_dir_path)
+    # Check out main and pull the latest changes
+    run_command("git checkout main", cwd=fd_stock_dir_path)
+    run_command("git pull upstream main", cwd=fd_stock_dir_path)
 
-        # Update the meta.yaml file
-        update_meta_yaml(meta_file_path, version, SHA256)
+    # Create and switch to a new branch named after the new version
+    run_command(f"git checkout -b {version}", cwd=fd_stock_dir_path)
 
-        # Add the updated meta.yaml file to the staging area
-        run_command("git add recipe/meta.yaml", cwd=fd_stock_dir_path)
+    # Update the meta.yaml file
+    update_meta_yaml(meta_file_path, version, SHA256)
 
-        # Commit the changes
-        run_command(
-            f'git commit -m "Update conda package to {version}"', cwd=fd_stock_dir_path
-        )
+    # Add the updated meta.yaml file to the staging area
+    run_command("git add recipe/meta.yaml", cwd=fd_stock_dir_path)
 
-        # Push the new branch to your origin repository
-        run_command(f"git push origin {version}", cwd=fd_stock_dir_path)
+    # Commit the changes
+    run_command(
+        f'git commit -m "Update conda package to {version}"', cwd=fd_stock_dir_path
+    )
 
-        # Create a pull request using GitHub CLI
-        pr_command = (
-            f"gh pr create --base main --head {username}:{version} "
-            f"--title 'Update meta.yaml to {version}' "
-            f"--body 'Updated meta.yaml to version {version} with SHA value of {SHA256}'"
-        )
+    # Push the new branch to your origin repository
+    run_command(f"git push origin {version}", cwd=fd_stock_dir_path)
 
-        # Run the PR create command in the appropriate directory
-        run_command(pr_command, cwd=fd_stock_dir_path)
+    # Create a pull request using GitHub CLI
+    pr_command = (
+        f"gh pr create --base main --head {username}:{version} "
+        f"--title 'Update meta.yaml to {version}' "
+        f"--body 'Updated meta.yaml to version {version} with SHA value of {SHA256}'"
+    )
 
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to execute command: {e.cmd}")
-        print(f"Error message: {e.stderr}")
-        raise
+    # Run the PR create command in the appropriate directory
+    run_command(pr_command, cwd=fd_stock_dir_path)
 
 
 """


### PR DESCRIPTION
This script streamlines the process of updating Python package versions and
their corresponding SHA256 hash in a meta.yaml file, followed by creating a
PR into the GitHub feedstock repository.

Workflow:
- The user is prompted to enter the name of a PyPI package.
- Retrieve the feedstock directory and `meta.yaml` file paths
- Fetch the latest versions and `SHA256` hashes from PyPI.
- Display the latest PyPI versions, asking the user to choose the version.
- Fetch the user's GitHub username using the GitHub CLI for authentication
- Update the `meta.yaml` file with the new version and SHA256
- Commit these changes, pushes them to GitHub, and creates a PR


## How to run

Given that we follow the standard folder structure under `dev`

- `dev/<package-name>-feedstock/...`
- `dev/release-scripts/...`

We can run `cf_release.py` using the absolute path:

```
python /Users/imac/dev/release-scripts/cf_release.py
```

## Demo

```
imac@imacs-iMac dev % python /Users/imac/dev/release-scripts/cf_release.py
Q1. Please enter the PyPI package name Ex) diffpy.pdfgui: bg-mpl-stylesheets

The latest versions of bg-mpl-stylesheets are:
 - Version: 0.4.1, SHA256: 35de...f2a4
 - Version: 0.4.0rc1, SHA256: 897c...559d
 - Version: 0.4.0, SHA256: 2a29...11a9
 - Version: 0.3.2, SHA256: 0240...b706

Q2. Would you like to proceed with the latest version 0.4.1? [Y/n]: n
Please enter the version you would like to use: 0.4.0rc1
You've selected version 0.4.0rc1 with SHA256 897c...559d for bg-mpl-stylesheets.

We will now update the meta.yaml file and create a PR into the feedstock repository.
```

https://github.com/conda-forge/bg-mpl-stylesheets-feedstock/pull/23