### PR TITLE
Set default repository in GitHub CLI to remove warning

### DIFF
--- a/cf_release.py
+++ b/cf_release.py
@@ -102,14 +102,14 @@ def update_meta_yaml(meta_file_path, new_version, new_sha256):
 
     with open(meta_file_path, "w") as file:
         for line in lines:
-            if "{%- set version =" in line:
-                line = f'{{%- set version = "{new_version}" -%}}\n'
+            if "set version" in line:
+                line = f'{{% set version = "{new_version}" %}}\n'
             elif "sha256:" in line:
                 line = f"  sha256: {new_sha256}\n"
             file.write(line)
 
 
-def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username):
+def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username, package_name):
     """
     Create a PR from a branch name of <new_version>
     to the main branch of the feedstock repository.
@@ -135,7 +135,7 @@ def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username):
 
     # Explicit set <username>-<packagne_name>-feedstock as the default repo
     # for GitHub CLI
-    run_command("gh repo set-default bobleesj/cifkit-feedstock", cwd=cwd)
+    run_command(f"gh repo set-default {username}/{package_name}-feedstock", cwd=cwd)
 
     # Create a pull request using GitHub CLI
     pr_command = (
@@ -238,7 +238,7 @@ def main():
 
     # Run the shell command to update the .yml file and create a PR
     run_gh_shell_command(
-        fd_stock_dir_path, meta_file_path, new_version, SHA256, username
+        fd_stock_dir_path, meta_file_path, new_version, SHA256, username, package_name
     )
 
 

--- a/cf_release.py
+++ b/cf_release.py
@@ -102,7 +102,9 @@ def update_meta_yaml(meta_file_path, new_version, new_sha256):
 
     with open(meta_file_path, "w") as file:
         for line in lines:
-            if "set version" in line:
+            if "{%- set version =" in line:
+                line = f'{{%- set version = "{new_version}" -%}}\n'
+            elif "{% set version =" in line:
                 line = f'{{% set version = "{new_version}" %}}\n'
             elif "sha256:" in line:
                 line = f"  sha256: {new_sha256}\n"

--- a/cf_release.py
+++ b/cf_release.py
@@ -137,7 +137,7 @@ def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username, package
 
     # Explicit set <username>-<packagne_name>-feedstock as the default repo
     # for GitHub CLI
-    run_command(f"gh repo set-default {username}/{package_name}-feedstock", cwd=cwd)
+    run_command(f"gh repo set-default conda-forge/{package_name}-feedstock", cwd=cwd)
 
     # Create a pull request using GitHub CLI
     pr_command = (

--- a/cf_release.py
+++ b/cf_release.py
@@ -133,6 +133,10 @@ def run_gh_shell_command(cwd, meta_file_path, version, SHA256, username):
     # Push the new branch to your origin repository
     run_command(f"git push origin {version}", cwd=cwd)
 
+    # Explicit set <username>-<packagne_name>-feedstock as the default repo
+    # for GitHub CLI
+    run_command("gh repo set-default bobleesj/cifkit-feedstock", cwd=cwd)
+
     # Create a pull request using GitHub CLI
     pr_command = (
         f"gh pr create --base main --head {username}:{version} "


### PR DESCRIPTION
Fixes the warning message during PR creation by explicitly setting the default repository:

From

```
X No default remote repository has been set for this directory.
```

to

```
✓ Set conda-forge/<package_name>-feedstock as the default repository for the current directory
Creating pull request for bobleesj:1.0.2 into main in conda-forge/<package-name>-feedstock
```