### PR TITLE
Do not build wheel by default in PyPI release

### DIFF
--- a/release.py
+++ b/release.py
@@ -163,10 +163,10 @@ def create_option_parser():
     )
     
     rel_group.add_option(
-        "--wheel",
+        "--no-wheel",
         action="store_true",
-        dest="build_wheel",
-        help="Build a wheel and a source distribution for the PyPi release."
+        dest="build_no_wheel",
+        help="Provide source distribution only for the PyPi release."
     )
 
     rel_group.add_option(
@@ -351,15 +351,29 @@ def github_release(opts, pargs):
     
     # Cleanup
     call(f"rm -rf {tmp_dir}", release_dir)
-        
+
+   
 def pypi_release(opts, pargs):
     release_dir = pargs[0]
     version = pargs[1]
 
     db_warning = "Warning: No new distribution build. This occurs when there are no new changes to the source code since the previous release. Please check for any untracked changes and update your package changelog/release-history to reflect the newest version."
 
-    # Build wheel and source
-    if opts.build_wheel:
+    # Only upload source
+    if opts.build_no_wheel:
+        call("python -m build --sdist", release_dir)
+        # Upload using twine
+        no_tar = True
+        for file in list((release_dir / "dist").iterdir()):
+            if re.search(f".*{version}.*.tar.gz", file.name):
+                no_tar = False
+        if no_tar:
+            call(f"echo \"{db_warning}\"", release_dir)
+        else:
+            call(f"twine upload dist/*{version}*.tar.gz", release_dir)
+
+    # Build wheel and source (Default behavior)
+    else:
         call("python -m build", release_dir) 
         # Upload using twine
         no_tar = True
@@ -375,19 +389,6 @@ def pypi_release(opts, pargs):
             call(f"echo \"Warning: No wheel found.\"", release_dir)
         else:
             call(f"twine upload dist/*{version}*.tar.gz dist/*{version}*.whl", release_dir)
-
-    # Only upload source
-    else:
-        call("python -m build --sdist", release_dir)
-        # Upload using twine
-        no_tar = True
-        for file in list((release_dir / "dist").iterdir()):
-            if re.search(f".*{version}.*.tar.gz", file.name):
-                no_tar = False
-        if no_tar:
-            call(f"echo \"{db_warning}\"", release_dir)
-        else:
-            call(f"twine upload dist/*{version}*.tar.gz", release_dir)
 
 
 # Generate SHA256 Hash for a Conda-Forge Release

--- a/release.py
+++ b/release.py
@@ -358,6 +358,7 @@ def pypi_release(opts, pargs):
 
     db_warning = "Warning: No new distribution build. This occurs when there are no new changes to the source code since the previous release. Please check for any untracked changes and update your package changelog/release-history to reflect the newest version."
     build_wheel = not opts.no_wheel
+    
     # Build wheel and source
     if build_wheel:
         call("python -m build", release_dir) 

--- a/release.py
+++ b/release.py
@@ -438,7 +438,7 @@ if __name__ == "__main__":
     if opts.release and opts.pre_release:
         parser.error("Both release and pre-release specified. Please re-run the command specifying either release or pre_release.")
     
-    # Linking --c to set --no-wheel
+    # Linking --c to set --no-wheel for project with C/C++ extension
     if opts.c:
         opts.no_wheel = True
 

--- a/release.py
+++ b/release.py
@@ -53,63 +53,54 @@ def create_option_parser():
     vsn_group.add_option(
         "--changelog",
         action="store_true",
-        dest="changelog",
         help="Combine all update files in the news directory into a single changelog file."
     )
     
     vsn_group.add_option(
         "--cl-file",
         metavar="FILEPATH",
-        dest="cl_file",
         help="Name (and path if not in root) of changelog file. Default \'CHANGELOG.rst\'"
     )
     
     vsn_group.add_option(
         "--cl-news",
         metavar="NEWSDIR",
-        dest="cl_news",
         help="Location of news directory. Default is \'news\' in the root directory."
     )
     
     vsn_group.add_option(
         "--cl-template",
         metavar="TEMPLATE",
-        dest="cl_template",
         help="Name of template file. One will be auto-generated if one does not exist. Default \'TEMPLATE.rst\'."
     )
     
     vsn_group.add_option(
         "--cl-categories",
         metavar="CATLIST",
-        dest="cl_categories",
         help="List of categories to include in the changelog. Default \'Added, Changed, Deprecated, Removed, Fixed, Security\'."
     )
     
     vsn_group.add_option(
         "--cl-ignore",
         metavar="FILELIST",
-        dest="cl_ignore",
         help="List of files in news to ignore. The template file is always ignored."
     )
     
     vsn_group.add_option(
         "--cl-access-point",
         metavar="APSTRING",
-        dest="cl_access_point",
         help="All changes will be put in the change log after the access point. Default \'.. current developments\'."
     )
     
     vsn_group.add_option(
         "--tag",
         action="store_true",
-        dest="tag",
         help="Create and push a version tag to GitHub."
     )
     
     vsn_group.add_option(
         "--upstream",
         action="store_true",
-        dest="upstream",
         help="Push to upstream rather than origin."
     )
     
@@ -123,42 +114,36 @@ def create_option_parser():
     rel_group.add_option(
         "--release",
         action="store_true",
-        dest="release",
         help="Update the changelog, push the tag, upload to Github, and upload to PyPi."
     )
     
     rel_group.add_option(
         "--pre-release",
         action="store_true",
-        dest="pre_release",
         help="Push the tag, upload to Github, and upload to PyPi."
     )
     
     rel_group.add_option(
         "--github",
         action="store_true",
-        dest="github",
         help="Initiate a release on GitHub."
     )
     
     rel_group.add_option(
         "--gh-title",
         metavar="TITLE",
-        dest="gh_title",
         help="Title of GitHub release."
     )
     
     rel_group.add_option(
         "--gh-notes",
         metavar="NOTES",
-        dest="gh_notes",
         help="Release notes to be posted for GitHub release."
     )
     
     rel_group.add_option(
         "--pypi",
         action="store_true",
-        dest="pypi",
         help="Initiate a release on PyPi. Default is to upload the source distribution. Use the --wheel option to also build a wheel using python-build."
     )
     

--- a/release.py
+++ b/release.py
@@ -148,7 +148,7 @@ def create_option_parser():
     )
     
     rel_group.add_option(
-        "--no-wheel",
+        "-c", "--no-wheel",
         action="store_true",
         help="Provide source distribution only for the PyPi release."
     )

--- a/release.py
+++ b/release.py
@@ -148,7 +148,7 @@ def create_option_parser():
     )
 
     rel_group.add_option(
-        "--c",
+        "-c", "--c",
         action="store_true",
         help="Configure to release a project with C/C++ extension" 
     )

--- a/release.py
+++ b/release.py
@@ -363,7 +363,7 @@ def pypi_release(opts, pargs):
             call(f"twine upload dist/*{version}*.tar.gz dist/*{version}*.whl", release_dir)
 
     # Only upload source
-    else:
+    elif not build_wheel:
         call("python -m build --sdist", release_dir)
         # Upload using twine
         no_tar = True

--- a/release.py
+++ b/release.py
@@ -146,9 +146,15 @@ def create_option_parser():
         action="store_true",
         help="Initiate a release on PyPi. Default is to upload the source distribution. Use the --wheel option to also build a wheel using python-build."
     )
-    
+
     rel_group.add_option(
-        "-c", "--c", "--no-wheel",
+        "--c",
+        action="store_true",
+        help="Configure to release a project with C/C++ extension" 
+    )
+
+    rel_group.add_option(
+        "--no-wheel",
         action="store_true",
         help="Provide source distribution only for the PyPi release."
     )
@@ -431,6 +437,10 @@ if __name__ == "__main__":
 
     if opts.release and opts.pre_release:
         parser.error("Both release and pre-release specified. Please re-run the command specifying either release or pre_release.")
+    
+    # Linking --c to set --no-wheel
+    if opts.c:
+        opts.no_wheel = True
 
     # Set release directory to absolute path
     pargs[0] = Path(pargs[0]).resolve()
@@ -445,6 +455,7 @@ if __name__ == "__main__":
         opts.tag = True
         opts.github = True
         opts.pypi = True
+
     if opts.changelog:
         update_changelog(opts, pargs)
     if opts.tag:

--- a/release.py
+++ b/release.py
@@ -148,7 +148,7 @@ def create_option_parser():
     )
     
     rel_group.add_option(
-        "-c", "--no-wheel",
+        "-c", "--c", "--no-wheel",
         action="store_true",
         help="Provide source distribution only for the PyPi release."
     )


### PR DESCRIPTION
Locally testing with temporary print statements:

```
$../release-scripts/release.py . 0.1.0 --pre-release
Building wheel and source.

$../release-scripts/release.py . 0.1.0 --pre-release --no-wheel
Do not build wheel.
```