### PR TITLE
Use pytest-cov to run pytest instead of coverage to pytest

### DIFF
--- a/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
@@ -65,7 +65,7 @@ jobs:
           if ${{ inputs.headless }}; then
             xport DISPLAY=:99
           fi
-          coverage run -m pytest -vv -s
+          pytest --cov
           coverage report -m
           codecov
 


### PR DESCRIPTION
@Tieqiong agreed that it is a way to resolve the 0% codecov problem. 

**Motivation:**
We shall use `pytest-cov` instead of using `coverage` to run pytest. The previous codecov 0% problem error occurred because the `tests` folder has been moved to the top directory level and coverage isn't able to import diffpy.<package> due to the namespace.

https://github.com/Billingegroup/release-scripts/issues/30

