### PR TITLE
Use pytest --cov for v0 for matrix/codecov CI

### DIFF
--- a/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
@@ -65,7 +65,7 @@ jobs:
           if ${{ inputs.headless }}; then
             xport DISPLAY=:99
           fi
-          coverage run -m pytest -vv -s
+          pytest --cov
           coverage report -m
           codecov
 


### PR DESCRIPTION
Update `v0` to match the `main` branch. 

The `main` branch uses `pytest --cov`

`v0` has not been synced with `main`.