### PR TITLE
Sync recent changes on main to v0

### DIFF
--- a/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
@@ -18,6 +18,10 @@ on:
         default: false
         required: false
         type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Codecov token'
+        required: true
 
 jobs:
   coverage:


### PR DESCRIPTION
Sync recent changes on main to v0

also add secret input for codecov.

Syncing main and v0 could be a bit extra work, so to make sure everything runs correctly we should be making PR to v0 first.