### PR TITLE
Fail news CI when no additional news .rst file is added to main branch

### DIFF
--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -41,18 +41,20 @@ def main():
     has_news_added = check_news_file(pr)
     old_comment = get_old_comment(pr)
 
-    if old_comment:
-        print("Found an existing comment from bot")
-        if has_news_added:
-            print("Delete warning from bot, since news items is added.")
+    if has_news_added:
+        if old_comment:
+            print("Found an existing comment from bot")
+            print("Delete warning from bot, since news item is added.")
             old_comment.delete()
-    elif not has_news_added:
+    else:
         print("No news item found")
-
-        pr.create_issue_comment(
-            """\
-**Warning!** No news item is found for this PR. If this is an user facing change/feature/fix,
- please add a news item by copying the format from `news/TEMPLATE.rst`.
+        if old_comment:
+            print("Old warning remains relevant, no action needed.")
+        else:
+            pr.create_issue_comment(
+                """\
+**Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
+please add a news item by copying the format from `news/TEMPLATE.rst`.
 """
         )
         assert False


### PR DESCRIPTION
Closes #39 

The change leads to CI failing when no additional *.rst is added to `main`. I tested it using my own Python package.

<img width="739" alt="Screenshot 2024-09-19 at 9 07 12 AM" src="https://github.com/user-attachments/assets/60d770c7-a9cd-4715-868b-3372cb81d3f2">
