### PR TITLE
Fix typo from xport to export for validate test on pr.yml

### DIFF
--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Validate ${{ inputs.project }}
         run: |
           if ${{ inputs.headless }}; then
-            xport DISPLAY=:99
+            export DISPLAY=:99
+            
           fi
           python -m pytest


### PR DESCRIPTION
https://github.com/diffpy/diffpy.pdfgui/pull/211#issuecomment-2372883385

pdfgui CI didn't work due to the typo:

```
... line 2: xport: command not found
Error: Process completed with exit code 127.
```