### PR TITLE
Use Python v3.12 for CI mini-conda env to avoid failed tests due to dependencies not supporting Python 3.13

### DIFF
--- a/.github/workflows/_publish-docs-on-release.yml
+++ b/.github/workflows/_publish-docs-on-release.yml
@@ -32,6 +32,7 @@ jobs:
           auto-update-conda: true
           environment-file: environment.yml
           auto-activate-base: false
+          python-version: 3.12
 
       - name: Conda config
         run: >-

--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -37,6 +37,7 @@ jobs:
           auto-update-conda: true
           environment-file: environment.yml
           auto-activate-base: false
+          python-version: 3.12
 
       - name: Conda config
         run: >-


### PR DESCRIPTION
A day ago, `conda-forge` released Python `3.13`: https://anaconda.org/conda-forge/python/files?type=conda

Without explicitly setting our environment to `3.12`, tests began to fail shown below:

<img width="709" alt="Screenshot 2024-10-09 at 11 35 25 PM" src="https://github.com/user-attachments/assets/8184ddab-ba86-4ea6-83b8-483892d1011f">

An issue is created later to remove Python 3.12 in our centralized workflow.