### PR TITLE
Use GitHub Personal Access Token to push to `main` to update CHANGELOG.rst during GitHub CI release

### DIFF
--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -114,12 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     if: always()  # This job will always initiate regardless of the success or failure of the needed jobs
     steps:
-      - name: Fail pypi-publish step if github-(pre)-release step failed
+      - name: Fail pypi-publish job if github-(pre)-release job failed
         run: |
           if [ "${{ needs.github-pre-release.result }}" == 'success' ] || [ "${{ needs.github-release.result }}" == 'success' ]; then
             echo "Ready for PyPI release..."
           else
-            echo "Previous github-(pre)-release step failed; exiting..."
+            echo "Previous github-(pre)-release job failed; exiting..."
             exit 1
           fi
 

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -12,9 +12,40 @@ on:
       PYPI_TOKEN:
         description: 'PyPI token'
         required: true
+      PAT_TOKEN:
+        description: 'GitHub Personal Access Token'
+        required: true
 
 jobs:
+  tag-check:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_valid: ${{ steps.tag-check.outputs.tag_valid }}
+    steps:
+      - name: Extract and validate tag for (pre)-release
+        id: tag-check
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+
+          # Check if the tag matches the pattern, e.g. 3.1.32 or 0.1.3rc0
+          if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
+            echo "tag_valid=true" >> $GITHUB_OUTPUT
+          fi
+
+  privilege-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check user role
+        run: |
+          if [ "${{ github.actor }}" != "sbillinge" ]; then
+            echo "Error: Unauthorized user"
+            exit 1
+          fi
+          echo "User sbillinge is allowed to run this workflow."
+        
   build-package:
+    needs: [tag-check, privilege-check]
+    if: needs.tag-check.outputs.tag_valid == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +62,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Update CHANGELOG.rst with the latest news
         run: |
@@ -82,12 +114,12 @@ jobs:
     runs-on: ubuntu-latest
     if: always()  # This job will always initiate regardless of the success or failure of the needed jobs
     steps:
-      - name: Fail pypi-publish job if github-(pre)-release job failed
+      - name: Fail pypi-publish step if github-(pre)-release step failed
         run: |
           if [ "${{ needs.github-pre-release.result }}" == 'success' ] || [ "${{ needs.github-release.result }}" == 'success' ]; then
             echo "Ready for PyPI release..."
           else
-            echo "Previous github-(pre)-release job failed; exiting..."
+            echo "Previous github-(pre)-release step failed; exiting..."
             exit 1
           fi
 

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -42,7 +42,7 @@ jobs:
             exit 1
           fi
           echo "User sbillinge is allowed to run this workflow."
-        
+
   build-package:
     needs: [tag-check, privilege-check]
     if: needs.tag-check.outputs.tag_valid == 'true'


### PR DESCRIPTION

Full release:
<img width="1053" alt="Screenshot 2024-10-21 at 12 29 39 PM" src="https://github.com/user-attachments/assets/a450ac8f-0057-42c6-9f18-7dea09172e73">

Pre-release:
<img width="1062" alt="Screenshot 2024-10-21 at 12 29 57 PM" src="https://github.com/user-attachments/assets/71717ef5-18e1-4177-a4a6-70fd3bc2ff9b">


