### PR TITLE
Add Codecov CI / comment report in each PR

### DIFF
--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -72,7 +72,7 @@ jobs:
           pytest --cov
           coverage report -m
           codecov
-          
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -18,6 +18,10 @@ on:
         default: false
         required: false
         type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        description: 'Codecov token'
+        required: true
 
 jobs:
   validate:
@@ -64,6 +68,14 @@ jobs:
         run: |
           if ${{ inputs.headless }}; then
             export DISPLAY=:99
-
           fi
-          python -m pytest
+          pytest --cov
+          coverage report -m
+          codecov
+          
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          verbose: true
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/templates/tests-on-pr.yml
+++ b/.github/workflows/templates/tests-on-pr.yml
@@ -14,3 +14,5 @@ jobs:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}
       headless: {{ HEADLESS/false }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
CI passes with a comment when coverage has gone up or remains the same:

<img width="633" alt="Screenshot 2024-11-01 at 7 20 13 PM" src="https://github.com/user-attachments/assets/7061819f-a688-4e9e-b0fb-0ce69365a496">

CI fails when coverage decreases:

<img width="807" alt="Screenshot 2024-11-01 at 8 19 11 PM" src="https://github.com/user-attachments/assets/2e89e74d-d4f6-40ac-8e39-8cb8ae6420b1">
