### PR TITLE
fix capitalize error in manual workflow update

### DIFF
--- a/update_workflow.py
+++ b/update_workflow.py
@@ -59,9 +59,9 @@ def get_user_input(prompt, default, param_name):
 
     user_value = input(f"{prompt} (default: {default}): ").strip()
     if user_value.lower() == "false":
-        value = False
+        value = "false"
     elif user_value.lower() == "true":
-        value = True
+        value = "true"
     elif user_value:
         value = user_value
     else:


### PR DESCRIPTION
This script is used when we want to manually update workflow without recookiecut. 

Fixing wrong [literals](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#literals) for boolean (wrong capitalization). This is a separate replicate from cookiecutter hooks, and the cookiecutter side is correct.

@sbillinge please review