### PR TITLE
Migrate codecov-action from v4 to v5

### DIFF
--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -79,7 +79,7 @@ jobs:
           codecov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           verbose: true
           fail_ci_if_error: true


### PR DESCRIPTION
Closes https://github.com/Billingegroup/cookiecutter/issues/183 - Migrate Codecov Actions from v4 to v5 to prevent Test on PR Codecov Upload fails

2 files globally modified. 