### PR TITLE
Skip news files containing "no news"  for `CHANGELOG.rst` compilation

### DIFF
--- a/.github/workflows/update-changelog.py
+++ b/.github/workflows/update-changelog.py
@@ -21,6 +21,10 @@ def extract_news_items(file_path):
     with open(file_path, "r") as file:
         for line in file:
             line = line.strip()
+            
+            # Skip lines indicating no news
+            if line.lower().startswith("* no news"):
+                continue
 
             # Check if the line is a category header
             if line.startswith("**") and line.endswith(":**"):

--- a/.github/workflows/update-changelog.py
+++ b/.github/workflows/update-changelog.py
@@ -21,7 +21,7 @@ def extract_news_items(file_path):
     with open(file_path, "r") as file:
         for line in file:
             line = line.strip()
-            
+
             # Skip lines indicating no news
             if line.lower().startswith("* no news"):
                 continue


### PR DESCRIPTION
Close #111 - this is a simple solution: enforcing each PR to create a news .rst file.

I have tested using a fork:

<img width="592" alt="Screenshot 2024-12-19 at 3 38 45 PM" src="https://github.com/user-attachments/assets/e8b9cddc-506b-4615-b6eb-a6e8d1e5f399" />

0.2.4 above correctly filters the ones starting with "no news"