### PR TITLE
ci: Delete/remove release tag after CHANGELOG.rst modified in `main`, build docs as a part of the release workflow after github release

### DIFF
--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -126,7 +126,6 @@ jobs:
         with:
           prerelease: true
           generate_release_notes: true
-          draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
   github-release:
@@ -155,7 +154,43 @@ jobs:
         with:
           body_path: CHANGELOG.txt
           token: ${{ secrets.GITHUB_TOKEN }}
-          draft: true
+
+  pypi-publish:
+    needs: [github-pre-release, github-release]
+    runs-on: ubuntu-latest
+    if: always()  # This job will always initiate regardless of the success or failure of the needed jobs
+    steps:
+      - name: Fail pypi-publish job if github-(pre)-release job failed
+        run: |
+          if [ "${{ needs.github-pre-release.result }}" == 'success' ] || [ "${{ needs.github-release.result }}" == 'success' ]; then
+            echo "Ready for PyPI release..."
+          else
+            echo "Previous github-(pre)-release job failed; exiting..."
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: '**/*' # Make sure all files are downloaded, including wheels
+          path: dist
+          merge-multiple: true
+
+      - name: Setup Python for PyPI upload
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Twine
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+
+      - name: Publish package to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          twine upload dist/* --verbose
 
   docs:
     needs: [github-pre-release, github-release]

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -123,6 +123,14 @@ jobs:
           body_path: CHANGELOG.txt
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  docs:
+    needs: [github-pre-release, github-release]
+    if: always()
+    uses: ./.github/workflows/_publish-docs-on-release.yml
+    with:
+      project: ${{ inputs.project }}
+      c_extension: ${{ inputs.c_extension }}
+
   pypi-publish:
     needs: [github-pre-release, github-release]
     runs-on: ubuntu-latest

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Fail delete-create-new-tag job if CHANGELOG update failed
         run: |
           if [ "${{ needs.update-changelog.result }}" == 'success' ]; then
-            echo "Ready to delete and create new tag containing the latest CHANGLEOG.rst update in the main branch..."
+            echo "Ready to delete and create new tag containing the latest CHANGELOG.rst update in the main branch..."
           else
             echo "Previous update-changelog job failed; exiting..."
             exit 1
@@ -101,7 +101,7 @@ jobs:
         run: |
           git tag -d "${{ github.ref_name }}"
           git push origin ":${{ github.ref_name }}"
-      - name: Create a new tag (Expect commit commit has to match with that of main branch)
+      - name: Create a new tag (Expect commit SHA to match with that of main branch)
         run: |
           git tag "${{ github.ref_name }}"
           git push origin "${{ github.ref_name }}"

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -75,6 +75,37 @@ jobs:
           commit_message: update changelog
           branch: main
 
+  delete-create-new-tag:
+    # For a full release, we delete and create a new tag to reflect the latest changes in the CHANGELOG.rst.
+    # Recall that during the full release, the `main` branch's CHANGELOG.rst has been updated, and we want the
+    # tag to reflect the latest changes in the CHANGELOG.rst done by the update-changelog above.
+    # For more discussions, please read https://github.com/Billingegroup/release-scripts/pull/120
+    needs: [update-changelog]
+    # Always run this job for a full release but fail if the update-changelog job previously failed.
+    if: "always() && !contains(github.ref, 'rc')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail delete-create-new-tag job if CHANGELOG update failed
+        run: |
+          if [ "${{ needs.update-changelog.result }}" == 'success' ]; then
+            echo "Ready to delete and create new tag containing the latest CHANGLEOG.rst update in the main branch..."
+          else
+            echo "Previous update-changelog job failed; exiting..."
+            exit 1
+          fi
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Delete the tag
+        run: |
+          git tag -d "${{ github.ref_name }}"
+          git push origin ":${{ github.ref_name }}"
+      - name: Create a new tag (Expect commit commit has to match with that of main branch)
+        run: |
+          git tag "${{ github.ref_name }}"
+          git push origin "${{ github.ref_name }}"
+
   github-pre-release:
     needs: [build-pure-python-package, build-non-pure-python-package]
     if: "always() && contains(github.ref, 'rc')"
@@ -94,10 +125,11 @@ jobs:
         with:
           prerelease: true
           generate_release_notes: true
+          draft: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
   github-release:
-    needs: [update-changelog]
+    needs: [delete-create-new-tag]
     if: "always() && !contains(github.ref, 'rc')"
     runs-on: ubuntu-latest
     steps:
@@ -122,6 +154,7 @@ jobs:
         with:
           body_path: CHANGELOG.txt
           token: ${{ secrets.GITHUB_TOKEN }}
+          draft: true
 
   docs:
     needs: [github-pre-release, github-release]
@@ -130,40 +163,3 @@ jobs:
     with:
       project: ${{ inputs.project }}
       c_extension: ${{ inputs.c_extension }}
-
-  pypi-publish:
-    needs: [github-pre-release, github-release]
-    runs-on: ubuntu-latest
-    if: always()  # This job will always initiate regardless of the success or failure of the needed jobs
-    steps:
-      - name: Fail pypi-publish job if github-(pre)-release job failed
-        run: |
-          if [ "${{ needs.github-pre-release.result }}" == 'success' ] || [ "${{ needs.github-release.result }}" == 'success' ]; then
-            echo "Ready for PyPI release..."
-          else
-            echo "Previous github-(pre)-release job failed; exiting..."
-            exit 1
-          fi
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: '**/*' # Make sure all files are downloaded, including wheels
-          path: dist
-          merge-multiple: true
-
-      - name: Setup Python for PyPI upload
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install Twine
-        run: |
-          python -m pip install --upgrade pip
-          pip install twine
-
-      - name: Publish package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/* --verbose

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Fail github-release job if CHANGELOG update failed
         run: |
-          if [ "${{ needs.delete-create-new-tag }}" == 'success' ]; then
+          if [ "${{ needs.delete-create-new-tag.result }}" == 'success' ]; then
             echo "Ready to release on GitHub..."
           else
             echo "Previous update-changelog job failed; exiting..."

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - name: Fail github-release job if CHANGELOG update failed
         run: |
-          if [ "${{ needs.update-changelog.result }}" == 'success' ]; then
+          if [ "${{ needs.delete-create-new-tag }}" == 'success' ]; then
             echo "Ready to release on GitHub..."
           else
             echo "Previous update-changelog job failed; exiting..."

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -99,6 +99,7 @@ jobs:
           ref: main
       - name: Delete the tag
         run: |
+          git fetch --tags
           git tag -d "${{ github.ref_name }}"
           git push origin ":${{ github.ref_name }}"
       - name: Create a new tag (Expect commit SHA to match with that of main branch)

--- a/.github/workflows/_publish-docs-on-release.yml
+++ b/.github/workflows/_publish-docs-on-release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out ${{ inputs.project }}
         uses: actions/checkout@v4
         with:
-          ref: main  # Fetch the main branch with CHANGELOG.rst modified during full release
+          ref: ${{ github.ref }}
 
       - name: Initialize miniconda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/_publish-docs-on-release.yml
+++ b/.github/workflows/_publish-docs-on-release.yml
@@ -25,7 +25,7 @@ on:
         type: boolean
 
 jobs:
-  docs:
+  build-deploy:
     defaults:
       run:
         shell: bash -l {0}
@@ -35,7 +35,7 @@ jobs:
       - name: Check out ${{ inputs.project }}
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Fetches branches and tags
+          ref: main  # Fetch the main branch with CHANGELOG.rst modified during full release
 
       - name: Initialize miniconda
         uses: conda-incubator/setup-miniconda@v3


### PR DESCRIPTION
Closes https://github.com/Billingegroup/release-scripts/issues/94

I think it is better to read this PR https://github.com/diffpy/diffpy.utils/pull/312 first since it's related and I provide a bit more context on the problem.

Please see in-line comments: