### PR TITLE
Add 'scikit-package' doc link for writing news file for `check-news-CI` comment

### DIFF
--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -1,6 +1,6 @@
 """Check if the PR has a news item.
 
-Put a warning comment and check fails if it doesn't.
+Put a warning comment and return `assert False` if the PR does not contain a news file.
 """
 
 import os

--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -59,7 +59,7 @@ def main():
                 """\
 **Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
 please add a news item by copying the format from `news/TEMPLATE.rst`.
-For best practices, please visit 
+For best practices, please visit
 https://billingegroup.github.io/scikit-package/frequently-asked-questions.html#billinge-group-standards.
 """
             )

--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -60,7 +60,7 @@ def main():
 **Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
 please add a news item by copying the format from `news/TEMPLATE.rst`.
 For best practices, please visit
-https://Billingegroup.github.io/cookiecutter/cookiecutter-guide.html#news-file-guide.
+https://Billingegroup.github.io/scikit-package/cookiecutter-guide.html#news-file-guide.
 """
             )
         assert False

--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -1,6 +1,6 @@
 """Check if the PR has a news item.
 
-Put a warning comment if it doesn't.
+Put a warning comment and check fails if it doesn't.
 """
 
 import os
@@ -59,6 +59,8 @@ def main():
                 """\
 **Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
 please add a news item by copying the format from `news/TEMPLATE.rst`.
+For best practices, please visit
+https://Billingegroup.github.io/cookiecutter/cookiecutter-guide.html#news-file-guide.
 """
             )
         assert False

--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -59,8 +59,8 @@ def main():
                 """\
 **Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
 please add a news item by copying the format from `news/TEMPLATE.rst`.
-For best practices, please visit
-https://Billingegroup.github.io/scikit-package/cookiecutter-guide.html#news-file-guide.
+For best practices, please visit 
+https://billingegroup.github.io/scikit-package/frequently-asked-questions.html#billinge-group-standards.
 """
             )
         assert False


### PR DESCRIPTION
Closes https://github.com/Billingegroup/cookiecutter/issues/220

The doc isn't deployed yet...

For now, this PR is in draft mode. I will write "ready for review" once the doc is deployed.