### PR TITLE
Add default (required) value to template workflow .yml file

### DIFF
--- a/.github/workflows/templates/build-wheel-release-upload.yml
+++ b/.github/workflows/templates/build-wheel-release-upload.yml
@@ -12,7 +12,7 @@ jobs:
     with:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}
-      github_admin_username: {{ GITHUB_ADMIN_USERNAME }}
+      github_admin_username: {{ GITHUB_ADMIN_USERNAME/username }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
### Problem

<img width="648" alt="Screenshot 2025-01-02 at 2 49 46 PM" src="https://github.com/user-attachments/assets/bcd3e98f-2615-40ea-82b8-4fc25d42cd0b" />

I noticed that `github_admin_username: {{ GITHUB_ADMIN_USERNAME }}` isn't being populated when a new project is created via `cookiecutter`.

### Proposed solution

It seems like a template .yml has a default value that is overwritten by the user input `[3/16] project_owner_github_username (sbillinge):` as shown in the sections in `project` and `c_extension`. (Please see the code under `Files changed`)
