### PR TITLE
fix: empty c extention api doc

### DIFF
--- a/.github/workflows/_publish-docs-on-release.yml
+++ b/.github/workflows/_publish-docs-on-release.yml
@@ -58,7 +58,7 @@ jobs:
           if ${{ inputs.c_extension }}; then
             conda install --file requirements/build.txt
           fi
-          python -m pip install . --no-deps
+          python -m pip install -e . --no-deps
 
       - name: Start Xvfb
         if: ${{ inputs.headless }}


### PR DESCRIPTION
@sbillinge In order for sphinx to grab the api from the c extension file we need to build it in the repository directory. Thus `-e .` install is needed instead of `.`.