### PR TITLE
chore: ensure `.github` template files are in prettified format

### DIFF
--- a/.github/workflows/templates/build-wheel-release-upload.yml
+++ b/.github/workflows/templates/build-wheel-release-upload.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - '*'  # Trigger on all tags initially, but tag and release privilege are verified in _build-wheel-release-upload.yml
+      - "*" # Trigger on all tags initially, but tag and release privilege are verified in _build-wheel-release-upload.yml
 
 jobs:
   release:

--- a/.github/workflows/templates/check-news-item.yml
+++ b/.github/workflows/templates/check-news-item.yml
@@ -3,7 +3,7 @@ name: Check for News
 on:
   pull_request_target:
     branches:
-    - main
+      - main
 
 jobs:
   check-news-item:


### PR DESCRIPTION
When a new project is created with `skpkg`, we want to ensure it's in already prettified format:

Ref: https://github.com/diffpy/diffpy.similarity/pull/2
<img width="1012" alt="Screenshot 2025-02-06 at 12 38 49 PM" src="https://github.com/user-attachments/assets/7df7feb9-03fd-4735-ba12-ea1f50070b9d" />


