### PR TITLE
ci: create a new `test-on-pr` CI workflow without Codecov, headless testing, and build installation

### DIFF
--- a/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
+++ b/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
@@ -1,0 +1,47 @@
+name: Tests on PR
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: 'Python version for Conda environment'
+        default: 3.13
+        required: false
+        type: number
+
+jobs:
+  validate:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out project
+        uses: actions/checkout@v4
+
+      - name: Initialize miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          auto-update-conda: true
+          environment-file: environment.yml
+          auto-activate-base: false
+          python-version: ${{ inputs.python_version }}
+
+      - name: Conda config
+        run: >-
+          conda config --set always_yes yes
+          --set changeps1 no
+
+      - name: Install package and requirements
+        run: |
+          conda install --file requirements/conda.txt
+          conda install --file requirements/test.txt
+          python -m pip install . --no-deps
+
+      - name: Run unit tests
+        run: |
+          pytest --cov
+          coverage report -m
+          codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
-Please read the following for contributors:
+Please read the following guidelines for contributors:
 
-- `_tests-on-pr.yml` is used in `scikit-package`
-- `_tests-on-pr-no-codecov-no-headless.yml` is used in `skpkg-package-system`. No Codecov, no build, no headless testing.
-- We make PRs to `main` and then we manually merged from `main` to `v0`.
+How are the files in the repository maintained and used?
+
+- We create PRs to `main` and then manually merge from `main` to `v0`.
+- We then use reusable scripts located in the `v0` branch.
+
+Where are the `.github/workflows` used?
+
+- `_tests-on-pr.yml` is used in `scikit-package`.
+- `_tests-on-pr-no-codecov-no-headless.yml` is used in `skpkg-package-system`. It does not include Codecov, builds, or headless testing.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+Please read the following for contributors:
+
+- `_tests-on-pr.yml` is used in `scikit-package`
+- `_tests-on-pr-no-codecov-no-headless.yml` is used in `skpkg-package-system`. No Codecov, no build, no headless testing.
+- We make PRs to `main` and then we manually merged from `main` to `v0`.


### PR DESCRIPTION
Addresses https://github.com/Billingegroup/scikit-package-system/issues/4

For level-4 in skpkg, I think it's much simpler to create a new workflow file... the existing `test-on-pr` is a bit complicated logic dealing with headless testing, install build packages, codecov, etc.

I am also thinking that some users may just want to copy this simple `test-on-pr` and implement it on their own packages too. 