### PR TITLE
refactor: adopt semantic versioning standard for pre-release ex) 0.0.1-rc.1, instead of 0.0.1rc1

### DIFF
--- a/.github/workflows/_release_tag_privilege_check.yml
+++ b/.github/workflows/_release_tag_privilege_check.yml
@@ -17,7 +17,7 @@ jobs:
         # Check if the tag matches the pattern, e.g. 3.1.32 or 0.1.3rc0
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then
+          if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
             echo "Valid tag: $TAG_NAME"
           else
             echo "Invalid tag: $TAG_NAME"


### PR DESCRIPTION
addresses https://github.com/Billingegroup/scikit-package/issues/384

## 1. Expect to pass

<img width="277" alt="Screenshot 2025-05-04 at 2 17 03 PM" src="https://github.com/user-attachments/assets/06ab64a7-956e-4c2c-b4aa-01b47a082435" />

## 2. Expected to fail

<img width="325" alt="Screenshot 2025-05-04 at 2 17 12 PM" src="https://github.com/user-attachments/assets/6d681620-a571-4407-bd15-6624a8fc1a85" />

## 3. Expected to pass

<img width="307" alt="Screenshot 2025-05-04 at 2 17 23 PM" src="https://github.com/user-attachments/assets/0e0c10ac-21e3-4665-ad98-fb172fa2a51c" />
