### PR TITLE
fix: macos goes to macos-latest and macos-15-intel

### DIFF
--- a/.github/workflows/_build-python-wheel-extension.yml
+++ b/.github/workflows/_build-python-wheel-extension.yml
@@ -63,8 +63,8 @@ jobs:
       matrix:
         buildplat:
           - ubuntu-latest
-          - macos-13
-          - macos-14
+          - macos-latest
+          - macos-15-intel
           - windows-latest
         python:
           - ${{ inputs.python_version }}
@@ -167,8 +167,8 @@ jobs:
       matrix:
         buildplat:
           - ubuntu-latest
-          - macos-13
-          - macos-14
+          - macos-latest
+          - macos-15-intel
           - windows-latest
         python:
           - ${{ inputs.python_version }}

--- a/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python_versions_json) }}
     steps:
       - name: Get the latest Python version from the matrix

--- a/.github/workflows/_matrix-no-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-no-codecov-on-merge-to-main.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-15-intel]
         python-version: ${{ fromJson(needs.get-python-versions.outputs.python_versions_json) }}
     steps:
       - name: Get the latest Python version from the matrix


### PR DESCRIPTION
moving mac builds to `macos-latest` (this will build arm) and `macos-15-intel` (this will build on intel) from `macos-13` and `macos-14` as we had before.  This is triggered because macos-13 is deprecated and will be removed as per https://github.com/actions/runner-images/issues/13046.   The intel builds will be removed next year too, but we may as well release our code built for intel as long as we can.

@bobleesj @Tieqiong I think this is ok, but happy to have you guys take a look.