### PR TITLE
fix: use python versions extract from `pyproject.toml` to build the matrix in github workflow

### DIFF
--- a/.github/workflows/_build-python-wheel-extension.yml
+++ b/.github/workflows/_build-python-wheel-extension.yml
@@ -11,8 +11,11 @@ on:
       python_version:
         description: 'Python versions to use for building'
         required: true
+        type: number
+      python_versions:
+        description: 'Python versions to use for building matrix'
+        required: true
         type: string
-        default: '["3.11", "3.12", "3.13"]'
 
 jobs:
   build_sdist:
@@ -67,7 +70,7 @@ jobs:
           - macos-latest
           - macos-15-intel
           - windows-latest
-        python: ${{ fromJSON(inputs.python_version) }}
+        python: ${{ fromJSON(inputs.python_versions) }}
 
     steps:
       - name: Check out
@@ -170,7 +173,7 @@ jobs:
           - macos-latest
           - macos-15-intel
           - windows-latest
-        python: ${{ fromJSON(inputs.python_version) }}
+        python: ${{ fromJSON(inputs.python_versions) }}
 
     steps:
       - name: Check out

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -50,6 +50,7 @@ jobs:
       c_extension: ${{ inputs.c_extension }}
       # Convert from number to string
       python_version: ${{ fromJSON(needs.get-python-version.outputs.python_version) }}
+      python_versions: ${{ needs.get-python-version.outputs.python_versions }}
 
   release-github:
     needs: [build-wheel]

--- a/.github/workflows/_build-wheel.yml
+++ b/.github/workflows/_build-wheel.yml
@@ -17,6 +17,10 @@ on:
         description: 'Python version to use for building'
         required: true
         type: number
+      python_versions:
+        description: 'Python versions to use for building matrix'
+        required: true
+        type: string
 
 jobs:
   python-pure:
@@ -31,3 +35,4 @@ jobs:
     with:
       project: ${{ inputs.project }}
       python_version: ${{ inputs.python_version }}
+      python_versions: ${{ inputs.python_versions }}

--- a/.github/workflows/_get-python-version-latest.yml
+++ b/.github/workflows/_get-python-version-latest.yml
@@ -12,6 +12,9 @@ on:
       python_version:
         description: 'Python version to use'
         value: ${{ jobs.extract-latest.outputs.python_version }}
+      python_versions:
+        description: 'Python versions for building matrix'
+        value: ${{ jobs.get-python-versions.outputs.python_versions_json }}
 
 jobs:
   get-python-versions:

--- a/news/fix-python-versions.rst
+++ b/news/fix-python-versions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Fix python version issues on building matrix in CI/CD.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION

### What problem does this PR address?

Closes #213 

### What should the reviewer(s) do?

Please see https://github.com/ycexiao/diffpy.pdffit2/actions/runs/19951737289. Matrices are correctly generated.

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
