### PR TITLE
chore: rename `python-version` and `python-versions` for clarity

### DIFF
--- a/.github/workflows/_build-python-wheel-extension.yml
+++ b/.github/workflows/_build-python-wheel-extension.yml
@@ -8,12 +8,12 @@ on:
         default: 'PROJECT_NAME'
         required: true
         type: string
-      python_version:
-        description: 'Python versions to use for building'
+      latest_python_version:
+        description: 'The latest suproted python version'
         required: true
         type: number
-      python_versions:
-        description: 'Python versions to use for building matrix'
+      python_versions_json:
+        description: 'JSON array of supported Python versions as strings'
         required: true
         type: string
 
@@ -36,7 +36,7 @@ jobs:
           channels: conda-forge
           auto-update-conda: true
           auto-activate-base: false
-          python-version: ${{ inputs.python_version }}
+          python-version: ${{ inputs.latest_python_version }}
 
       - name: Conda config
         run: >-
@@ -70,7 +70,7 @@ jobs:
           - macos-latest
           - macos-15-intel
           - windows-latest
-        python: ${{ fromJSON(inputs.python_versions) }}
+        python: ${{ fromJSON(inputs.python_versions_json) }}
 
     steps:
       - name: Check out
@@ -173,7 +173,7 @@ jobs:
           - macos-latest
           - macos-15-intel
           - windows-latest
-        python: ${{ fromJSON(inputs.python_versions) }}
+        python: ${{ fromJSON(inputs.python_versions_json) }}
 
     steps:
       - name: Check out

--- a/.github/workflows/_build-python-wheel-extension.yml
+++ b/.github/workflows/_build-python-wheel-extension.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       latest_python_version:
-        description: 'The latest suproted python version'
+        description: 'The latest supported python version'
         required: true
         type: number
       python_versions_json:

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -49,8 +49,8 @@ jobs:
       project: ${{ inputs.project }}
       c_extension: ${{ inputs.c_extension }}
       # Convert from number to string
-      python_version: ${{ fromJSON(needs.get-python-version.outputs.python_version) }}
-      python_versions: ${{ needs.get-python-version.outputs.python_versions }}
+      latest_python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
+      python_versions_json: ${{ needs.get-python-version.outputs.python_versions_json }}
 
   release-github:
     needs: [build-wheel]
@@ -63,7 +63,7 @@ jobs:
     uses: ./.github/workflows/_release-pypi.yml
     with:
       # Convert from number to string
-      python_version: ${{ fromJSON(needs.get-python-version.outputs.python_version) }}
+      python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
@@ -74,4 +74,4 @@ jobs:
       project: ${{ inputs.project }}
       c_extension: ${{ inputs.c_extension }}
       # Convert from number to string
-      python_version: ${{ fromJSON(needs.get-python-version.outputs.python_version) }}
+      python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}

--- a/.github/workflows/_build-wheel.yml
+++ b/.github/workflows/_build-wheel.yml
@@ -14,7 +14,7 @@ on:
         required: true
         type: boolean
       latest_python_version:
-        description: 'The latest suproted python version'
+        description: 'The latest supported python version'
         required: true
         type: number
       python_versions_json:

--- a/.github/workflows/_build-wheel.yml
+++ b/.github/workflows/_build-wheel.yml
@@ -13,12 +13,12 @@ on:
         default: false
         required: true
         type: boolean
-      python_version:
-        description: 'Python version to use for building'
+      latest_python_version:
+        description: 'The latest suproted python version'
         required: true
         type: number
-      python_versions:
-        description: 'Python versions to use for building matrix'
+      python_versions_json:
+        description: 'JSON array of supported Python versions as strings'
         required: true
         type: string
 
@@ -27,12 +27,12 @@ jobs:
     if: inputs.c_extension == false
     uses: ./.github/workflows/_build-python-wheel-pure.yml
     with:
-      python_version: ${{ inputs.python_version }}
+      python_version: ${{ inputs.latest_python_version }}
 
   python-extension:
     if: inputs.c_extension
     uses: ./.github/workflows/_build-python-wheel-extension.yml
     with:
       project: ${{ inputs.project }}
-      python_version: ${{ inputs.python_version }}
-      python_versions: ${{ inputs.python_versions }}
+      latest_python_version: ${{ inputs.latest_python_version }}
+      python_versions_json: ${{ inputs.python_versions_json }}

--- a/.github/workflows/_get-python-version-latest.yml
+++ b/.github/workflows/_get-python-version-latest.yml
@@ -9,11 +9,11 @@ on:
         required: false
         type: number
     outputs:
-      python_version:
-        description: 'Python version to use'
+      latest_python_version:
+        description: 'The latest suproted python version'
         value: ${{ jobs.extract-latest.outputs.python_version }}
-      python_versions:
-        description: 'Python versions for building matrix'
+      python_versions_json:
+        description: 'JSON array of supported Python versions as strings'
         value: ${{ jobs.get-python-versions.outputs.python_versions_json }}
 
 jobs:

--- a/.github/workflows/_get-python-version-latest.yml
+++ b/.github/workflows/_get-python-version-latest.yml
@@ -10,7 +10,7 @@ on:
         type: number
     outputs:
       latest_python_version:
-        description: 'The latest suproted python version'
+        description: 'The latest supported python version'
         value: ${{ jobs.extract-latest.outputs.python_version }}
       python_versions_json:
         description: 'JSON array of supported Python versions as strings'

--- a/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
+++ b/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
@@ -38,7 +38,7 @@ jobs:
           channels: conda-forge
           auto-update-conda: true
           auto-activate-base: false
-          python-version: ${{ needs.get-python-version.outputs.python_version }}
+          python-version: ${{ needs.get-python-version.outputs.latest_python_version }}
 
       - name: Conda config
         run: >-

--- a/.github/workflows/_tests-on-pr-no-codecov.yml
+++ b/.github/workflows/_tests-on-pr-no-codecov.yml
@@ -53,7 +53,7 @@ jobs:
           channels: conda-forge
           auto-update-conda: true
           auto-activate-base: false
-          python-version: ${{ needs.get-python-version.outputs.python_version }}
+          python-version: ${{ needs.get-python-version.outputs.latest_python_version }}
 
       - name: Conda config
         run: >-

--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -57,7 +57,7 @@ jobs:
           channels: conda-forge
           auto-update-conda: true
           auto-activate-base: false
-          python-version: ${{ needs.get-python-version.outputs.python_version }}
+          python-version: ${{ needs.get-python-version.outputs.latest_python_version }}
 
       - name: Conda config
         run: >-

--- a/news/rename-python-versions.rst
+++ b/news/rename-python-versions.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Rename ``python_version`` to ``latest_python_version`` and ``ppython_versions``  to ``python_versions_json`` in some places for clarity.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Closes #217 

The modifications started from `_get-python-version-latest.yml`.  `python_version` was renamed to `latest_python_version`, and `python_versions` were changed to `python_versions_json`. The renaming is kept to a minimum to not interfere with the flexibility of other workflows.



### What should the reviewer(s) do?

Building wheels and testing on PRs are affected by the changes.

For building wheels, it is tested in  https://github.com/ycexiao/diffpy.pdffit2/actions/runs/19994779996/job/57340655367.
Matrices are successfully built. The workflow failed due to `sphinx` issues. All related modified files are triggered in the testing workflow.

For Testing on PR,  it is tested in https://github.com/ycexiao/diffpy.pdffit2/actions/runs/19994795883/job/57340694832#step:9:426. The step `Initialize miniconda` is executed successfully. `_test-on-pr.yml` is triggered in the testing workflow.
