### PR TITLE
feat: allow to specify packages to be installed via pip

### DIFF
--- a/.github/workflows/_build-python-wheel-extension.yml
+++ b/.github/workflows/_build-python-wheel-extension.yml
@@ -16,6 +16,11 @@ on:
         description: 'JSON array of supported Python versions as strings'
         required: true
         type: string
+      pip_packages:  # e.g. '<package1> <package2>'
+        description: 'packages to install via pip'
+        default: ''
+        required: false
+        type: string
 
 jobs:
   build_sdist:
@@ -90,10 +95,18 @@ jobs:
           conda config --set always_yes yes
           --set changeps1 no
 
-      - name: Install requirements and build wheels
+      - name: Install requirements via conda
         run: |
           conda install --file requirements/conda.txt
           conda install --file requirements/pip.txt
+          conda install pip
+
+      - name: Install requirements via pip
+        if: ${{ inputs.pip_packages != '' }}
+        run: pip install ${{ inputs.pip_packages }}
+
+      - name: build wheels
+        run: |
           pip install --upgrade build
           python -m pip wheel --no-deps --wheel-dir ./dist .
 

--- a/.github/workflows/_build-python-wheel-pure.yml
+++ b/.github/workflows/_build-python-wheel-pure.yml
@@ -7,6 +7,11 @@ on:
         description: 'Python version to use for building'
         required: true
         type: number
+      pip_packages:  # e.g. '<package1> <package2>'
+        description: 'packages to install via pip'
+        default: ''
+        required: false
+        type: string
 
 jobs:
   build:
@@ -27,6 +32,11 @@ jobs:
       # Install build tool
       - name: Install build dependencies
         run: python -m pip install --upgrade build
+
+      # Install additional pip packages if specified
+      - name: Install additional pip packages
+        if: ${{ inputs.pip_packages != '' }}
+        run: python -m pip install ${{ inputs.pip_packages }}
 
       # Build the package (creates both .whl and .tar.gz in ./dist)
       - name: Build wheel and sdist

--- a/.github/workflows/_build-release-github-no-pypi-no-docs.yml
+++ b/.github/workflows/_build-release-github-no-pypi-no-docs.yml
@@ -22,6 +22,11 @@ on:
         default: 0
         required: false
         type: number
+      pip_packages:  # e.g. '<package1> <package2>'
+        description: 'packages to install via pip'
+        default: ''
+        required: false
+        type: string
     secrets:
       PAT_TOKEN:
         description: 'GitHub Personal Access Token'
@@ -53,6 +58,7 @@ jobs:
       # Convert from number to string
       latest_python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
       python_versions_json: ${{ needs.get-python-version.outputs.python_versions_json }}
+      pip_packages: ${{ inputs.pip_packages }}
 
   release-github:
     needs: [build-wheel]

--- a/.github/workflows/_build-release-github-no-pypi.yml
+++ b/.github/workflows/_build-release-github-no-pypi.yml
@@ -22,6 +22,11 @@ on:
         default: 0
         required: false
         type: number
+      pip_packages: # e.g. '<package1> <package2>'
+        description: 'packages to install via pip'
+        default: ''
+        required: false
+        type: string
     secrets:
       PAT_TOKEN:
         description: 'GitHub Personal Access Token'
@@ -53,6 +58,7 @@ jobs:
       # Convert from number to string
       latest_python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
       python_versions_json: ${{ needs.get-python-version.outputs.python_versions_json }}
+      pip_packages: ${{ inputs.pip_packages }}
 
   release-github:
     needs: [build-wheel]

--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -27,6 +27,11 @@ on:
         default: main
         required: false
         type: string
+      pip_packages:  # e.g. '<package1> <package2>'
+        description: 'packages to install via pip'
+        default: ''
+        required: false
+        type: string
     secrets:
       PYPI_TOKEN:
         description: 'PyPI token'
@@ -66,6 +71,7 @@ jobs:
       # Convert from number to string
       latest_python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
       python_versions_json: ${{ needs.get-python-version.outputs.python_versions_json }}
+      pip_packages: ${{ inputs.pip_packages }}
 
   release-github:
     needs: [build-wheel]

--- a/.github/workflows/_build-wheel.yml
+++ b/.github/workflows/_build-wheel.yml
@@ -13,6 +13,11 @@ on:
         default: false
         required: true
         type: boolean
+      pip_packages:
+        description: 'packages to install via pip'
+        default: '' # e.g. '<package1> <package2>'
+        required: false
+        type: string
       latest_python_version:
         description: 'The latest supported python version'
         required: true
@@ -28,6 +33,7 @@ jobs:
     uses: ./.github/workflows/_build-python-wheel-pure.yml
     with:
       python_version: ${{ inputs.latest_python_version }}
+      pip_packages: ${{ inputs.pip_packages }}
 
   python-extension:
     if: inputs.c_extension
@@ -36,3 +42,4 @@ jobs:
       project: ${{ inputs.project }}
       latest_python_version: ${{ inputs.latest_python_version }}
       python_versions_json: ${{ inputs.python_versions_json }}
+      pip_packages: ${{ inputs.pip_packages }}

--- a/news/add-pip-install.rst
+++ b/news/add-pip-install.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Allow to specify packages to be installed via pip.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

Close https://github.com/scikit-package/scikit-package/issues/639


Tested in https://github.com/ycexiao/scikit-package/actions/runs/25584321564/job/75109868630

1. Pure build is successful with chaco installed.
2. Several extension build fails because I uploaded unsupported python versions and `scikit-pacakge` is not intended for extension build.

The action is triggered by:
```
jobs:
  pure-build:
    uses: ycexiao/release-scripts/.github/workflows/_build-python-wheel-pure.yml@v0
    with:
      pip_packages: 'chaco icecream'
      python_version: 3.12

  extension-build:
    uses: ycexiao/release-scripts/.github/workflows/_build-python-wheel-extension.yml@v0
    with:
      project: 'PROJECT_NAME'
      pip_packages: 'chaco icecream'
      latest_python_version: 3.12
      python_versions_json: '["3.10", "3.11", "3.12"]'
```

### What should the reviewer(s) do?

Please review the modifications.

`_build-release-github-private-pure.yml`  is not modified because it didn't use `_build_wheel.yml` workflow. If it is needed I can also push another commit.

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->
