### PR TITLE
fix: use symbolic ref rather than sha to checkout

### DIFF
--- a/.github/workflows/_get-python-versions.yml
+++ b/.github/workflows/_get-python-versions.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
 
       - name: Extract Python versions from pyproject.toml
         id: set-versions

--- a/news/tag-ref.rst
+++ b/news/tag-ref.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Use symbolic reference to checkout when tag is relocated in the release workflow.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

In `diffpy.distanceprintter`: https://github.com/scikit-package/release-scripts/issues/283
and `diffpy.apps`: https://github.com/diffpy/diffpy.apps/actions/runs/25897000253/job/76112200404

there is:
```
  /usr/bin/git rev-parse refs/tags/0.1.0^{commit}
  e5c0908897300e02891b6254b32147bbfd15242f
  Error: The ref 'refs/tags/0.1.0' does not point to the expected commit '03ed227bf4fb8946b6b06ad4d281de387dd73252'. The ref may have been updated after the workflow was triggered.
```

triggered by `actions/checkout@v6` in `_release-docs.yaml`. 
The `actions/checkout@6` in `_release-pypi.yaml` works fine, and it has a 
```
with:
    ref: {{ github.ref }}
```
tell it to use the symbolic ref rather than the SHA.

### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->

Please merge it and re-run the workflow mentioned to see if it is fixed